### PR TITLE
Fix handling the case where the project name is a namespace like icrs…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,13 @@
  Changes
 =========
 
-1.0.2 (unreleased)
+1.1.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix handling the case where the project name is a namespace
+  (``icrs.releaser``), but the source directory on disk doesn't
+  include the namespace (``src/releaser``). This is a legacy case,
+  supported for projects that are transitioning to a standard layout.
 
 
 1.0.1 (2022-02-25)


### PR DESCRIPTION
….releaser, but the import name and name on disk only contains the second part like src/releaser.

This is a legacy case.